### PR TITLE
Fix issue with empty profile pic

### DIFF
--- a/services/user.service.go
+++ b/services/user.service.go
@@ -70,6 +70,9 @@ func (us *UserService) GetProfilePhoto(c *gin.Context) {
 			return err
 		}
 		peer := self.AsInputPeer()
+		if self.Photo == nil {
+			return nil
+		}
 		photo, _ := self.Photo.AsNotEmpty()
 		location := &tg.InputPeerPhotoFileLocation{Big: false, Peer: peer, PhotoID: photo.PhotoID}
 		buff, err := iterContent(c, client, location)


### PR DESCRIPTION
Hi. I just fixed an issue that was causing the app to crash when a user didn't have a profile pic set.

**Changes:**
- Implemented a conditional check to verify if `self.Photo` has a null value.

Please review and let me know if any further changes or adjustments are needed. Thank you.