### PR TITLE
Issue with empty profile pic

### DIFF
--- a/services/user.service.go
+++ b/services/user.service.go
@@ -71,6 +71,9 @@ func (us *UserService) GetProfilePhoto(c *gin.Context) {
 			return err
 		}
 		peer := self.AsInputPeer()
+		if self.Photo == nil {
+			return nil
+		}
 		photo, ok := self.Photo.AsNotEmpty()
 		if !ok {
 			return errors.New("profile not found")


### PR DESCRIPTION
Hi again. I just checked the last updates and noticed that you changed the profile checking logic. However, it seems that even by checking the second return value of `self.Photo.AsNotEmpty()`, the functionality doesn't work correctly when there is no profile picture set. I tested it myself with an account without profile picture. So I've taken the liberty to revert the code to the previous implementation.

**Changes:**
- Reverted to the previous conditional check to ensure proper handling when self.Photo is null.

Please review and let me know if any further changes or adjustments are needed. Thank you.